### PR TITLE
Pull version from package.json file

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,8 @@
 #addin nuget:?package=SharpZipLib
 #addin nuget:?package=Cake.Compression
 
-var currentNpmTarball = "https://registry.npmjs.org/chrome-aws-lambda/-/chrome-aws-lambda-1.11.2.tgz";
+using System.IO;
+using Newtonsoft.Json;
 
 var configuration = Argument("configuration", "Release");
 var version = AppVeyor.IsRunningOnAppVeyor ? AppVeyor.Environment.Build.Version : "0-dev";
@@ -30,6 +31,7 @@ Task("Build")
 Task("ExtractChromiumFromNpmPackage")
 	.Does(() =>
 	{
+		var currentNpmTarball = GetNpmTarballUrl();
 		DownloadFile(currentNpmTarball, "chrome-aws-lambda.tgz");
 		GZipUncompress("chrome-aws-lambda.tgz", "chrome-aws-lambda");
 	});
@@ -51,5 +53,13 @@ Task("UploadNugetPackages")
 Task("Default")
 	.IsDependentOn("Build")
 	.IsDependentOn("UploadNugetPackages");
-	
+
+string GetNpmTarballUrl()
+{
+	var json = System.IO.File.ReadAllText("package.json");
+	var package = JsonConvert.DeserializeObject<dynamic>(json);
+	var version = package.dependencies["chrome-aws-lambda"];
+	return $"https://registry.npmjs.org/chrome-aws-lambda/-/chrome-aws-lambda-{version}.tgz";
+}
+
 RunTarget(target);


### PR DESCRIPTION
Simplify the process of updating versions from the upstream NPM package.  This pulls the version from the Node.js `package.json` so when PRs come from Dependebot we can simply accept the PRs to do the update.