### PR TITLE
Multitarget netcoreapp2.1 and netstandard2.1

### DIFF
--- a/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromium.Puppeteer.Lambda.Dotnet.csproj
+++ b/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromium.Puppeteer.Lambda.Dotnet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Litmus</Company>
     <PackageLicenseUrl>https://github.com/litmus/HeadlessChromium.Puppeteer.Lambda.Dotnet/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
Since Lambda is waiting until CoreApp3.1 to support Lambda without a custom runtime, we need to support `netcoreapp2.1` and `netstandard2.1`

Add this via multitargeting