### PR TITLE
Update PuppeteerSharp to handle breaking API change

### DIFF
--- a/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromium.Puppeteer.Lambda.Dotnet.csproj
+++ b/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromium.Puppeteer.Lambda.Dotnet.csproj
@@ -36,6 +36,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="1.14.1" />
+    <PackageReference Include="PuppeteerSharp" Version="2.0.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves https://github.com/litmus/HeadlessChromium.Puppeteer.Lambda.Dotnet/issues/56

Looks like https://github.com/hardkoded/puppeteer-sharp/pull/1498 moved some classes around which broke API compatibility.  Creating a new build based on the tag after this change.