### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The chromium binary for this project has been extracted from the NPM project [ch
 # Usage
 Screenshot a URL as a byte[].  This project requires lambda to be configured as `netcoreapp3.1`
 ```
-var browserLauncher = new HeadlessChromiumPuppeterLauncher(logger);
+var browserLauncher = new HeadlessChromiumPuppeteerLauncher(logger);
 
 using(var browser = await browserLauncher.LaunchAsync())
 using(var page = await browser.NewPageAsync())


### PR DESCRIPTION
fix spelling of HeadlessChromiumPuppeterLauncher => HeadlessChromiumPuppeteerLauncher in sample code of README.md

Spun my wheels for a while trying to figure out why the type could not be found while trying this package out.