### PR TITLE
Include the version of SharpZipLib which is being brought in by Cake

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,8 +1,9 @@
-#addin nuget:?package=SharpZipLib
-#addin nuget:?package=Cake.Compression
+#addin nuget:?package=SharpZipLib&version=1.3.1
+#addin nuget:?package=Cake.Compression&version=0.2.6
 
 using System.IO;
 using Newtonsoft.Json;
+using ICSharpCode.SharpZipLib.GZip;
 
 var configuration = Argument("configuration", "Release");
 var version = AppVeyor.IsRunningOnAppVeyor ? AppVeyor.Environment.Build.Version : "0-dev";


### PR DESCRIPTION
Builds on the `main` branch have started [failing](https://ci.appveyor.com/project/brianfeucht/headlesschromium-puppeteer-lambda-dotnet/builds/40941077):

```
Preparing to run build script...
Running build script...

========================================
ExtractChromiumFromNpmPackage
========================================
An error occurred when executing task 'ExtractChromiumFromNpmPackage'.
Error: One or more errors occurred.
        Could not load file or assembly 'ICSharpCode.SharpZipLib, Version=1.3.1.9, Culture=neutral, PublicKeyToken=1b03e6acf1164f73' or one of its dependencies. The system cannot find the file specified.
```

This PR sets the specific version of the nuget addins so they are all pulling in the expected version of this nuget package.