### PR TITLE
Bump PuppeteerSharp from 5.1.0 to 7.0.0

### DIFF
--- a/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromium.Puppeteer.Lambda.Dotnet.csproj
+++ b/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromium.Puppeteer.Lambda.Dotnet.csproj
@@ -36,6 +36,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="5.1.0" />
+    <PackageReference Include="PuppeteerSharp" Version="7.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
My consumer was encountering the same `Cannot enterFrom in state Disposed` in the exact same fashion as described here:
https://github.com/hardkoded/puppeteer-sharp/issues/1870

That issue was addressed in the following commit:
https://github.com/hardkoded/puppeteer-sharp/commit/aa5fb4326d09239f506c6a5ba5b2f61a57f579ca

Local testing reveals that this issue cannot be reproduced with the latest 7.0.0 PuppeteerSharp.