### PR TITLE
Switch Lambda Binary NodeJs project to @sparticuz/chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Packages everything you need to run [PuppeteerSharp](https://github.com/kblok/pu
 [![Nuget status](https://img.shields.io/nuget/v/HeadlessChromium.Puppeteer.Lambda.Dotnet.svg?style=flat)](https://www.nuget.org/packages/HeadlessChromium.Puppeteer.Lambda.Dotnet)
 
 # Description
-The chromium binary for this project has been extracted from the NPM project [chrome-aws-lambda](https://github.com/alixaxel/chrome-aws-lambda).  It is automatically extracted to `/tmp/chromium` at runtime.
+The chromium binary for this project has been extracted from the NPM project [Sparticuz/chromium](https://github.com/Sparticuz/chromium).  It is automatically extracted to `/tmp/chromium` at runtime.
 
 # Usage
 Screenshot a URL as a byte[].  This project requires lambda to be configured as `netcoreapp3.1`

--- a/build.cake
+++ b/build.cake
@@ -64,8 +64,8 @@ string GetNpmTarballUrl()
 {
 	var json = System.IO.File.ReadAllText("package.json");
 	var package = JsonConvert.DeserializeObject<dynamic>(json);
-	var version = package.dependencies["chrome-aws-lambda"];
-	return $"https://registry.npmjs.org/chrome-aws-lambda/-/chrome-aws-lambda-{version}.tgz";
+	var version = package.dependencies["@sparticuz/chromium"];
+	return $"https://registry.npmjs.org/@sparticuz/chromium/-/chromium-{version}.tgz";
 }
 
 RunTarget(target);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
 	"name": "HeadlessChromium.Puppeteer.Lambda.Dotnet",
 	"version": "0.0.1-dev",
 	"dependencies": {
-		"chrome-aws-lambda": "10.0.0"
+		"@sparticuz/chromium": "107.0.0"
 	}
 }

--- a/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/ChromiumExtractor.cs
+++ b/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/ChromiumExtractor.cs
@@ -61,7 +61,7 @@ namespace HeadlessChromium.Puppeteer.Lambda.Dotnet
                 if (!File.Exists(ChromiumPath))
                 {
                     ExtractDependencies("aws.tar.br", "/tmp");
-                    ExtractDependencies("swiftshader.tar.br", "/tmp/swiftshader");
+                    ExtractDependencies("swiftshader.tar.br", "/tmp");
 
                     var compressedFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "chromium.br");
 

--- a/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromium.Puppeteer.Lambda.Dotnet.csproj
+++ b/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromium.Puppeteer.Lambda.Dotnet.csproj
@@ -4,12 +4,12 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Litmus</Company>
     <PackageLicenseUrl>https://github.com/litmus/HeadlessChromium.Puppeteer.Lambda.Dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <Copyright>2019 Litmus</Copyright>
+    <Copyright>2022 Litmus</Copyright>
     <PackageProjectUrl>https://github.com/litmus/HeadlessChromium.Puppeteer.Lambda.Dotnet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/litmus/HeadlessChromium.Puppeteer.Lambda.Dotnet</RepositoryUrl>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
-    <Version Condition="'$(VersionSuffix)' != ''">1.0.1.$(VersionSuffix)</Version>
+    <Version Condition="'$(VersionSuffix)' != ''">1.1.0.$(VersionSuffix)</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
The project we were depending on for chromium updates has [gone dark](https://github.com/alixaxel/chrome-aws-lambda/issues/282)

This updated dependency is a fork of the original and is running the latest [chromium version 107](https://en.wikipedia.org/wiki/Google_Chrome_version_history#Anchor_to_the_latest_release.)

Since this is more than just update library update, I bumped the project version a minor revision.  