### PR TITLE
Have dependabot keep sample project up to date to ensure compability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,19 @@ updates:
     interval: daily
     time: "04:00"
   rebase-strategy: disabled
+  ignore:
+    - dependency-name: "PuppeteerSharp"
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
     time: "04:00"
   rebase-strategy: disabled
+- package-ecosystem: nuget
+  directory: "/sample/SampleLambda"
+  schedule:
+    interval: daily
+    time: "04:00"
+  rebase-strategy: disabled
+  allow:
+    - dependency-name: "PuppeteerSharp"


### PR DESCRIPTION
Dependabot is trying to keep `PuppeteerSharp` up to date on the base project.  This is not our desired behavior as this will force consumers to use the latest version.  In order to allow consumers to use whatever version of this dependency they want, we need to keep this at the minimal version that supports the current API.  

To find out about breaking API changes, I've setup dependabot to update the SampleProject.  This will ensure that the latest version of PuppeteerSharp works with older nuget package we are building against.  