### PR TITLE
Add support for net8 Lambda Run Time 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
 	"name": "HeadlessChromium.Puppeteer.Lambda.Dotnet",
 	"version": "0.0.1-dev",
 	"dependencies": {
-		"@sparticuz/chromium": "123.0.0"
+		"@sparticuz/chromium": "123.0.1"
 	}
 }

--- a/sample/SampleLambda-dotnet8/HelloWorldHandler.cs
+++ b/sample/SampleLambda-dotnet8/HelloWorldHandler.cs
@@ -12,7 +12,12 @@ namespace SampleLambda
             var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             var browserLauncher = new HeadlessChromiumPuppeteerLauncher(loggerFactory);
 
-            await using (var browser = await browserLauncher.LaunchAsync())
+            var launchArgs = HeadlessChromiumPuppeteerLauncher.DefaultChromeArgs
+                .Append("--enable-logging")
+                .Append("--v=1")
+                .ToArray();
+
+            await using (var browser = await browserLauncher.LaunchAsync(launchArgs))
             await using (var page = await browser.NewPageAsync())
             {
                 await page.GoToAsync("https://www.google.com");

--- a/sample/SampleLambda-dotnet8/SampleLambda.csproj
+++ b/sample/SampleLambda-dotnet8/SampleLambda.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.1" />
     <PackageReference Include="HeadlessChromium.Puppeteer.Lambda.Dotnet" Version="1.1.0-dev" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="16.0.0" />
+    <PackageReference Include="PuppeteerSharp" Version="18.0.2" />
   </ItemGroup>
 
 </Project>

--- a/sample/SampleLambda-dotnet8/SampleLambda.csproj
+++ b/sample/SampleLambda-dotnet8/SampleLambda.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.1" />
     <PackageReference Include="HeadlessChromium.Puppeteer.Lambda.Dotnet" Version="1.1.0-dev" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="13.0.1" />
+    <PackageReference Include="PuppeteerSharp" Version="16.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We already have tests to validate this functionality.  Right now chrome is crashing when we try to load a page.  Seems like this is likely an issue with how the chromium build is interacting with AL2023

```
Navigating frame was detached
```

Updated docker builds will be found at https://gallery.ecr.aws/lambda/dotnet - new builds will always grab the latest docker image with the `8` tag

Similar issues in the chromium lib we are using:
 - https://github.com/Sparticuz/chromium/issues/200
 - https://github.com/Sparticuz/chromium/issues/206
 - https://github.com/Sparticuz/chromium/issues/271#issuecomment-2090949266

