### PR TITLE
Update dependabot config to keep dotnet specific version sample projects up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,32 @@ updates:
     time: "04:00"
   rebase-strategy: disabled
 - package-ecosystem: nuget
-  directory: "/sample/SampleLambda"
+  directory: "/sample/SampleLambda-dotnet6"
   schedule:
     interval: daily
     time: "04:00"
   rebase-strategy: disabled
   allow:
     - dependency-name: "PuppeteerSharp"
+    - dependency-name: "Amazon.Lambda.Core"
+    - dependency-name: "Amazon.Lambda.Serialization.Json"
+- package-ecosystem: nuget
+  directory: "/sample/SampleLambda-dotnet7"
+  schedule:
+    interval: daily
+    time: "04:00"
+  rebase-strategy: disabled
+  allow:
+    - dependency-name: "PuppeteerSharp"
+    - dependency-name: "Amazon.Lambda.Core"
+    - dependency-name: "Amazon.Lambda.Serialization.Json"
+- package-ecosystem: nuget
+  directory: "/sample/SampleLambda-dotnet8"
+  schedule:
+    interval: daily
+    time: "04:00"
+  rebase-strategy: disabled
+  allow:
+    - dependency-name: "PuppeteerSharp"
+    - dependency-name: "Amazon.Lambda.Core"
+    - dependency-name: "Amazon.Lambda.Serialization.Json"


### PR DESCRIPTION
I broke dependabot when I broke out the sample projects into individual dotnet versions.  This PR restores that functionality.