### PR TITLE
.NET 8 support

### DIFF
--- a/sample/SampleLambda-dotnet8/Dockerfile
+++ b/sample/SampleLambda-dotnet8/Dockerfile
@@ -1,5 +1,3 @@
-FROM public.ecr.aws/lambda/dotnet:6 AS fonts-base
-
 FROM public.ecr.aws/lambda/dotnet:8
 
 # Set the image's internal work directory
@@ -7,7 +5,6 @@ WORKDIR /var/task
   
 # Copy function code
 COPY "bin/Release/lambda-publish"  .
-COPY --from=fonts-base "/usr/share/fonts" "/usr/share/fonts"
   
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 CMD [ "SampleLambda::SampleLambda.HelloWorldHandler::Handle" ]

--- a/sample/SampleLambda-dotnet8/Dockerfile
+++ b/sample/SampleLambda-dotnet8/Dockerfile
@@ -1,3 +1,5 @@
+FROM public.ecr.aws/lambda/dotnet:6 AS fonts-base
+
 FROM public.ecr.aws/lambda/dotnet:8
 
 # Set the image's internal work directory
@@ -5,6 +7,7 @@ WORKDIR /var/task
   
 # Copy function code
 COPY "bin/Release/lambda-publish"  .
+COPY --from=fonts-base "/usr/share/fonts" "/usr/share/fonts"
   
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 CMD [ "SampleLambda::SampleLambda.HelloWorldHandler::Handle" ]

--- a/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/ChromiumExtractor.cs
+++ b/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/ChromiumExtractor.cs
@@ -102,6 +102,7 @@ namespace HeadlessChromium.Puppeteer.Lambda.Dotnet
                         logger.LogWarning("Operating environment unexpected. Unable to extract correct dependencies.");
                     }
 
+                    ExtractDependencies("fonts.tar.br", "/tmp");
                     ExtractDependencies("swiftshader.tar.br", "/tmp");
 
                     var compressedFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "chromium.br");

--- a/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/ChromiumExtractor.cs
+++ b/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/ChromiumExtractor.cs
@@ -72,15 +72,6 @@ namespace HeadlessChromium.Puppeteer.Lambda.Dotnet
                 logger.LogDebug("/tmp doesn't exist.  Is this running on lambda?");
             }
 
-            if(!Directory.Exists("/tmp/.fonts"))
-            {
-                // A fix for the "Check failed: InitDefaultFont(). Could not find the default font" error
-                Directory.CreateDirectory("/tmp/.fonts");
-                File.WriteAllText(
-                    "/tmp/.fonts/font.conf", 
-                    @"<?xml version=""1.0""?><!DOCTYPE fontconfig SYSTEM ""fonts.dtd""><fontconfig><dir>/opt/usr/share/fonts</dir><dir>/tmp/.fonts</dir></fontconfig>");
-            }
-
             // Quick bale if exec exists
             if (File.Exists(ChromiumPath))
             {

--- a/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromium.Puppeteer.Lambda.Dotnet.csproj
+++ b/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromium.Puppeteer.Lambda.Dotnet.csproj
@@ -32,6 +32,10 @@
       <Pack>true</Pack>
       <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
+    <Content Include="..\..\chrome-aws-lambda\package\bin\fonts.tar.br">
+      <Pack>true</Pack>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
+    </Content>
     <Content Include="..\..\chrome-aws-lambda\package\bin\swiftshader.tar.br">
       <Pack>true</Pack>
       <PackageCopyToOutput>true</PackageCopyToOutput>


### PR DESCRIPTION
While debugging the `SampleLambda-dotnet8` project locally, I noticed some warnings/errors regarding fonts.

I then compared the contents of the `public.ecr.aws/lambda/dotnet:8` Docker image to the `public.ecr.aws/lambda/dotnet:6` image, and apparently the AL2 based image contains some fonts and also a lot of fontconfigs, while the AL2023 based image does not. When copying over the fonts from the AL2 based image to the AL2023 based image, the tests are passing (and the resulting PNG is also looking good imo).

Then I noticed the npm package also contains a `fonts.tar.br` file. By extracting it along with the other dependencies, copying over the fonts from the AL2 based image isn't needed anymore; the tests are still passing.

I haven't been able to test on an actual Lambda, but hopefully this will help.