### PR TITLE
.net8 AOT

### DIFF
--- a/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromium.Puppeteer.Lambda.Dotnet.csproj
+++ b/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromium.Puppeteer.Lambda.Dotnet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Litmus</Company>
     <PackageLicenseUrl>https://github.com/litmus/HeadlessChromium.Puppeteer.Lambda.Dotnet/blob/master/LICENSE</PackageLicenseUrl>
@@ -42,8 +42,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="9.0.0" />
+    <PackageReference Include="PuppeteerAot" Version="16.2.0" />
   </ItemGroup>
 </Project>

--- a/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromiumPuppeteerLauncher.cs
+++ b/src/HeadlessChromium.Puppeteer.Lambda.Dotnet/HeadlessChromiumPuppeteerLauncher.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
-using PuppeteerSharp;
+using PuppeteerAot;
 using System;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
Not sure if going away from PuppeteerSharp is the direction you want to take, but they mentioned this:
https://github.com/hardkoded/puppeteer-sharp/issues/2643
https://github.com/chenrensong/PuppeteerAot/tree/main

The following changes do appear to work.  In my lambda the following are working: unpacking chromium, navigation, screenshot, EvaluateFunctionAsync

Cuts my "Init Duration" times from 300-400ms to ~150ms.