### PR TITLE
Update puppeter sharp v19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,20 @@
 version: 2
 updates:
 - package-ecosystem: nuget
-  directory: "/"
+  directories:
+    - "/sample/SampleLambda-dotnet6"
+    - "/sample/SampleLambda-dotnet7"
+    - "/sample/SampleLambda-dotnet8"
+  schedule:
+    interval: daily
+    time: "04:00"
+  rebase-strategy: disabled
+  allow:
+    - dependency-name: "PuppeteerSharp"
+    - dependency-name: "Amazon.Lambda.Core"
+    - dependency-name: "Amazon.Lambda.Serialization.Json"
+- package-ecosystem: nuget
+  directory: "/src/HeadlessChromium.Puppeteer.Lambda.Dotnet"
   schedule:
     interval: daily
     time: "04:00"
@@ -14,33 +27,3 @@ updates:
     interval: daily
     time: "04:00"
   rebase-strategy: disabled
-- package-ecosystem: nuget
-  directory: "/sample/SampleLambda-dotnet6"
-  schedule:
-    interval: daily
-    time: "04:00"
-  rebase-strategy: disabled
-  allow:
-    - dependency-name: "PuppeteerSharp"
-    - dependency-name: "Amazon.Lambda.Core"
-    - dependency-name: "Amazon.Lambda.Serialization.Json"
-- package-ecosystem: nuget
-  directory: "/sample/SampleLambda-dotnet7"
-  schedule:
-    interval: daily
-    time: "04:00"
-  rebase-strategy: disabled
-  allow:
-    - dependency-name: "PuppeteerSharp"
-    - dependency-name: "Amazon.Lambda.Core"
-    - dependency-name: "Amazon.Lambda.Serialization.Json"
-- package-ecosystem: nuget
-  directory: "/sample/SampleLambda-dotnet8"
-  schedule:
-    interval: daily
-    time: "04:00"
-  rebase-strategy: disabled
-  allow:
-    - dependency-name: "PuppeteerSharp"
-    - dependency-name: "Amazon.Lambda.Core"
-    - dependency-name: "Amazon.Lambda.Serialization.Json"

--- a/sample/SampleLambda-dotnet6/SampleLambda.csproj
+++ b/sample/SampleLambda-dotnet6/SampleLambda.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.1" />
     <PackageReference Include="HeadlessChromium.Puppeteer.Lambda.Dotnet" Version="1.1.0-dev" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="13.0.1" />
+    <PackageReference Include="PuppeteerSharp" Version="19.0.1" />
   </ItemGroup>
 
 </Project>

--- a/sample/SampleLambda-dotnet7/SampleLambda.csproj
+++ b/sample/SampleLambda-dotnet7/SampleLambda.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.1" />
     <PackageReference Include="HeadlessChromium.Puppeteer.Lambda.Dotnet" Version="1.1.0-dev" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="13.0.1" />
+    <PackageReference Include="PuppeteerSharp" Version="19.0.1" />
   </ItemGroup>
 
 </Project>

--- a/sample/SampleLambda-dotnet8/SampleLambda.csproj
+++ b/sample/SampleLambda-dotnet8/SampleLambda.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.1" />
     <PackageReference Include="HeadlessChromium.Puppeteer.Lambda.Dotnet" Version="1.1.0-dev" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="13.0.1" />
+    <PackageReference Include="PuppeteerSharp" Version="19.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This update should be getting handled by dependabot.  Hopefully it will going forward.

Version 19 of PuppeteerSharp has support for AOT compilation.  Update to this version to make sure we do not have any breaking changes.