### PR TITLE
Add attributes required to build an AOT image

### DIFF
--- a/sample/SampleLambda-dotnet8/HelloWorldHandler.cs
+++ b/sample/SampleLambda-dotnet8/HelloWorldHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Amazon.Lambda.Core;
 using HeadlessChromium.Puppeteer.Lambda.Dotnet;
 using Microsoft.Extensions.Logging;
+using System.Text.Json.Serialization;
 
 namespace SampleLambda
 {
@@ -21,5 +22,18 @@ namespace SampleLambda
 
             return await File.ReadAllBytesAsync("./google.png");
         }
+    }
+
+    /// <summary>
+    /// This class is used to register the input event and return type for the FunctionHandler method with the System.Text.Json source generator.
+    /// There must be a JsonSerializable attribute for each type used as the input and return type or a runtime error will occur
+    /// from the JSON serializer unable to find the serialization information for unknown types.
+    /// </summary>
+    [JsonSerializable(typeof(string))]
+    public partial class LambdaFunctionJsonSerializerContext : JsonSerializerContext
+    {
+        // By using this partial class derived from JsonSerializerContext, we can generate reflection free JSON Serializer code at compile time
+        // which can deserialize our class and properties. However, we must attribute this class to tell it what types to generate serialization code for.
+        // See https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-source-generation
     }
 }

--- a/sample/SampleLambda-dotnet8/SampleLambda.csproj
+++ b/sample/SampleLambda-dotnet8/SampleLambda.csproj
@@ -4,6 +4,11 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
+    <!-- Generate Native AOT image -->
+    <PublishAot>true</PublishAot>
+    <StripSymbols>true</StripSymbols>
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/SampleLambda-dotnet8/aws-lambda-tools-defaults.json
+++ b/sample/SampleLambda-dotnet8/aws-lambda-tools-defaults.json
@@ -6,5 +6,6 @@
   "function-timeout": 60,
   "function-handler": "SampleLambda::SampleLambda.HelloWorldHandler::Handle",
   "package-type": "image",
-  "docker-host-build-output-dir": "./bin/Release/lambda-publish"
+  "docker-host-build-output-dir": "./bin/Release/lambda-publish",
+  "msbuild-parameters": "--self-contained true"
 }


### PR DESCRIPTION
Flip our .NET 8 build to use the new AOT capabilities