### PR TITLE
Update Dependabot and sample project references to ensure they are on the latest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,8 @@ updates:
     interval: daily
     time: "04:00"
   rebase-strategy: disabled
-  allow:
-    - dependency-name: "PuppeteerSharp"
-    - dependency-name: "Amazon.Lambda.Core"
-    - dependency-name: "Amazon.Lambda.Serialization.Json"
+  ignore:
+    - dependency-name: "HeadlessChromium.Puppeteer.Lambda.Dotnet"
 - package-ecosystem: nuget
   directory: "/src/HeadlessChromium.Puppeteer.Lambda.Dotnet"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
   rebase-strategy: disabled
   ignore:
     - dependency-name: "PuppeteerSharp"
+    - dependency-name: "Microsoft.Extensions.Logging"
 - package-ecosystem: npm
   directory: "/"
   schedule:

--- a/sample/SampleLambda-dotnet6/SampleLambda.csproj
+++ b/sample/SampleLambda-dotnet6/SampleLambda.csproj
@@ -17,10 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.1" />
     <PackageReference Include="HeadlessChromium.Puppeteer.Lambda.Dotnet" Version="1.1.0-dev" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.2.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="PuppeteerSharp" Version="19.0.1" />
   </ItemGroup>
 

--- a/sample/SampleLambda-dotnet7/SampleLambda.csproj
+++ b/sample/SampleLambda-dotnet7/SampleLambda.csproj
@@ -17,10 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.1" />
     <PackageReference Include="HeadlessChromium.Puppeteer.Lambda.Dotnet" Version="1.1.0-dev" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.2.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="PuppeteerSharp" Version="19.0.1" />
   </ItemGroup>
 

--- a/sample/SampleLambda-dotnet8/SampleLambda.csproj
+++ b/sample/SampleLambda-dotnet8/SampleLambda.csproj
@@ -17,10 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.1" />
     <PackageReference Include="HeadlessChromium.Puppeteer.Lambda.Dotnet" Version="1.1.0-dev" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.2.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="PuppeteerSharp" Version="19.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
The goal for dependencies on this project is to be compatible with the latest versions while supporting the oldest version possible.  That way we are not forcing newer versions downstream.  

To ensure we accomplish this we want to make sure our sample projects are running the latest versions.  This PR updates those transitive dependencies and Dependabot config to do this work for us.