### PR TITLE
Add placeholder to create artifacts directory to support dependendabot

### DIFF
--- a/artifacts/placeholder
+++ b/artifacts/placeholder
@@ -1,0 +1,2 @@
+Fix for
+error NU1301: The local source '/artifacts/' doesn't exist.


### PR DESCRIPTION
Dependabot isn't able to do its thing because this directory is missing.

https://github.com/litmus/HeadlessChromium.Puppeteer.Lambda.Dotnet/actions/runs/11042089590/job/30673725563