### PR TITLE
Manually update puppeteer sharp dependencies 

### DIFF
--- a/sample/SampleLambda-dotnet6/SampleLambda.csproj
+++ b/sample/SampleLambda-dotnet6/SampleLambda.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="19.0.1" />
+    <PackageReference Include="PuppeteerSharp" Version="20.0.2" />
   </ItemGroup>
 
 </Project>

--- a/sample/SampleLambda-dotnet7/SampleLambda.csproj
+++ b/sample/SampleLambda-dotnet7/SampleLambda.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="19.0.1" />
+    <PackageReference Include="PuppeteerSharp" Version="20.0.2" />
   </ItemGroup>
 
 </Project>

--- a/sample/SampleLambda-dotnet8/SampleLambda.csproj
+++ b/sample/SampleLambda-dotnet8/SampleLambda.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="19.0.1" />
+    <PackageReference Include="PuppeteerSharp" Version="20.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We have found [a bug](https://github.com/litmus/HeadlessChromium.Puppeteer.Lambda.Dotnet/actions/runs/11042302948/job/30674371538) with [dependabot](https://github.com/dependabot/dependabot-core/issues/10672), so this package isn't being at latest.

So this manually updates [to latest](https://www.nuget.org/packages/PuppeteerSharp/).  

In the future, either github will fix the bug or we will change the way we are handling this dependency.